### PR TITLE
Addendum to slam dividing line rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ Once each single player on one side has set the ball up at least one time, an of
 
 An offensive strike must bounce on the opposing team's side of the table one time.  Any more bounces is a point yielded to the offending team.  If the ball does not bounce one time on the opposing side, then the point goes to the opposing team.
 
-**NOTE: Returning the ball to the opposing side IS NOT PERMITTED if the offensive player's bat goes passed the physical or logical line dividing the table (ie. the net).**
+**NOTE: Returning the ball to the opposing side IS NOT PERMITTED if the offensive player's paddle goes past the physical or logical line dividing the table (ie. the net).**
+**ADDENDUM TO NOTE: All shots to opposing side considered a [spike](#spike) must be hit by a player whose feet are behind the table. This makes the area from the edge of the table to the net a no slam zone, or [NO MAN'S SLAM](#no-mans-slam)**
 
 ## Equipment
  
-The game is typically played with table tennis racquets and a table tennis ball.  Although there _could_ be alternatives, each player should use the same type of racquet.
+The game is typically played with table tennis paddles and a table tennis ball.  Although there _could_ be alternatives, each player should use the same type of paddle.
 
 ## Surroundings
 
@@ -75,3 +76,11 @@ There are surrounding surfaces that are considered "fair game" and will keep the
 * The table.
 * Vertical surfaces that are NOT human (eg. walls).
 * Pipes (the cylindrical shape presents too much grey area).
+
+# Glossary
+
+## spike
+A spike is defined as a final shot or attack following a volley, returned to the opposing side hit in such a manner that the ball is not returnable.
+
+## No Man's Slam
+The area between the edge of the table and the net. No [spikes](#spike) or slams are permitted in this zone.

--- a/README.md
+++ b/README.md
@@ -4,29 +4,27 @@ _A multi-player racquet sport that is a mix between Volley Ball and Table Tennis
 
 ## Description
 
-A designated player from the serving team will commence in _service_.  The player serves the ball to the opposing side in the same way that a "Doubles Table Tennis" match would be served. 
+A designated player from the serving team will commence in _service_. The player serves the ball to the opposing side in the same way that a "Doubles Table Tennis" match would be served.
 
-Each player on the returning side "sets" the ball (ie. hits the ball up for the next teammate).  The ball is set between each teammate at least once before an offensive play is attempted.
+Each player on the returning side "sets" the ball (ie. hits the ball up for the next teammate). The ball is set between each teammate at least once before an offensive play is attempted.
 
-The returning team either commits an error and yields the point to the opposition; or, an offensive attempt is made by returning the ball to the original side of the table for the other team to handle.  The process continues until one of the teams score.
+The returning team either commits an error and yields the point to the opposition; or, an offensive attempt is made by returning the ball to the original side of the table for the other team to handle. The process continues until one of the teams score.
 
 ## Starting the game
 
-A random player sets the ball up for the next player to their left; moving in a clockwise direction.  Each succeeding player will also set the ball up.  The first player to make an error yields the first _service_ to the opposing team.
-
+A random player sets the ball up for the next player to their left; moving in a clockwise direction. Each succeeding player will also set the ball up. The first player to make an error yields the first _service_ to the opposing team.
 
 ## Number of players
 
-* The number of players _MUST_ be symmetrical.  In other words, there must not be a different number of players on one team compared to the other.
+- The number of players _MUST_ be symmetrical. In other words, there must not be a different number of players on one team compared to the other.
 
-* Three (3) to five (5) players is ideal for continuous gameplay (although any number of players is permitted as previously mentioned).
-
+- Three (3) to five (5) players is ideal for continuous gameplay (although any number of players is permitted as previously mentioned).
 
 ## Positions
 
-Players usually form a semi-circle around their side of the table.  This is, however, not required since some players might choose to stand further back for defensive purposes.
+Players usually form a semi-circle around their side of the table. This is, however, not required since some players might choose to stand further back for defensive purposes.
 
-In a typical game consisting of 3 - 5 players per team, there is on player in the middle (on deck to be the server).  The other players are in the surrounding areas of the table.
+In a typical game consisting of 3 - 5 players per team, there is on player in the middle (on deck to be the server). The other players are in the surrounding areas of the table.
 
 When a service is complete, the players rotate in a clockwise fashion.
 
@@ -44,8 +42,9 @@ _The side of which the serve hits on the table is not relevant._
 ## Scoring
 
 In order to win the match, a team must:
-* Be the first to reach 21 points.
-* Have a 2 point lead.
+
+- Be the first to reach 21 points.
+- Have a 2 point lead.
 
 If 21 is reached but there is not a lead of 2 points, then the game continues until the 2 point lead is reached.
 
@@ -53,35 +52,32 @@ If 21 is reached but there is not a lead of 2 points, then the game continues un
 
 A round of defence starts when either the ball is served into play, or the opposing team makes an offensive strike.
 
-Each player MUST hit the ball one time before an offensive move is made (ie. each player must set the ball up for their next teammate).  The final teammate in the series has the choice of either setting the ball again, or returning with an offensive strike.
+Each player MUST hit the ball one time before an offensive move is made (ie. each player must set the ball up for their next teammate). The final teammate in the series has the choice of either setting the ball again, or returning with an offensive strike.
 
-NOTE: No player shall hit the ball two times in a row.  Ever!
+NOTE: No player shall hit the ball two times in a row. Ever!
 
 ## Offense
 
-Once each single player on one side has set the ball up at least one time, an offensive strike is permitted, but not required.  The team could continue setting the ball, assuming that a player never hits the ball twice in a row.
+Once each single player on one side has set the ball up at least one time, an offensive strike is permitted, but not required. The team could continue setting the ball, assuming that a player never hits the ball twice in a row.
 
-An offensive strike must bounce on the opposing team's side of the table one time.  Any more bounces is a point yielded to the offending team.  If the ball does not bounce one time on the opposing side, then the point goes to the opposing team.
+An offensive strike must bounce on the opposing team's side of the table one time. Any more bounces is a point yielded to the offending team. If the ball does not bounce one time on the opposing side, then the point goes to the opposing team.
 
 **NOTE: Returning the ball to the opposing side IS NOT PERMITTED if the offensive player's paddle goes past the physical or logical line dividing the table (ie. the net).**
 
-**ADDENDUM TO NOTE: All shots to opposing side considered a [spike](#spike) must be hit by a player whose feet are behind the table. This makes the area from the edge of the table to the net a no slam zone, or [NO MAN'S SLAM](#no-mans-slam)**
-
 ## Equipment
- 
-The game is typically played with table tennis paddles and a table tennis ball.  Although there _could_ be alternatives, each player should use the same type of paddle.
+
+The game is typically played with table tennis paddles and a table tennis ball. Although there _could_ be alternatives, each player should use the same type of paddle.
 
 ## Surroundings
 
 There are surrounding surfaces that are considered "fair game" and will keep the ball in play.
-* The table.
-* Vertical surfaces that are NOT human (eg. walls).
-* Pipes (the cylindrical shape presents too much grey area).
+
+- The table.
+- Vertical surfaces that are NOT human (eg. walls).
+- Pipes (the cylindrical shape presents too much grey area).
 
 # Glossary
 
 ## spike
-A spike is defined as a final shot or attack following a volley, returned to the opposing side hit in such a manner that the ball becomes much more difficult to return, and in some cases is not returnable.
 
-## No Man's Slam
-The area between the edge of the table and the net. No [spikes](#spike) or slams are permitted in this zone.
+A spike is defined as a final shot or attack following a volley, returned to the opposing side hit in such a manner that the ball becomes much more difficult to return, and in some cases is not returnable.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ There are surrounding surfaces that are considered "fair game" and will keep the
 # Glossary
 
 ## spike
-A spike is defined as a final shot or attack following a volley, returned to the opposing side hit in such a manner that the ball is not returnable.
+A spike is defined as a final shot or attack following a volley, returned to the opposing side hit in such a manner that the ball becomes much more difficult to return, and in some cases is not returnable.
 
 ## No Man's Slam
 The area between the edge of the table and the net. No [spikes](#spike) or slams are permitted in this zone.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Once each single player on one side has set the ball up at least one time, an of
 An offensive strike must bounce on the opposing team's side of the table one time.  Any more bounces is a point yielded to the offending team.  If the ball does not bounce one time on the opposing side, then the point goes to the opposing team.
 
 **NOTE: Returning the ball to the opposing side IS NOT PERMITTED if the offensive player's paddle goes past the physical or logical line dividing the table (ie. the net).**
+
 **ADDENDUM TO NOTE: All shots to opposing side considered a [spike](#spike) must be hit by a player whose feet are behind the table. This makes the area from the edge of the table to the net a no slam zone, or [NO MAN'S SLAM](#no-mans-slam)**
 
 ## Equipment


### PR DESCRIPTION
I propose an addendum to move the line for which _slams_ are allowed to be moved behind the 
edge of the table. I feel that this would make games more competitive and slams easier to defend.

It should still be acceptable to play a ball from the sides, it just can't be a slam.

I also added a glossary.